### PR TITLE
Fix getSubShopIdByBrowserLanguagePrefix

### DIFF
--- a/Components/ShopFinder.php
+++ b/Components/ShopFinder.php
@@ -171,7 +171,7 @@ class ShopFinder
     {
         foreach ($languages as $language) {
             $browserLanguage = strtolower($language);
-            $currentLanguageArray = explode('-', $browserLanguage);
+            $currentLanguageArray = explode('_', $browserLanguage);
             $browserLanguagePrefix = $currentLanguageArray[0];
 
             foreach ($this->subShops as $subshop) {


### PR DESCRIPTION
In the [Widget-Controllers getBrowserLanguages()-Function](https://github.com/shopwareLabs/SwagBrowserLanguage/blob/master/Controllers/Widgets/SwagBrowserLanguage.php#L159) all hyphens in the detected preferred browser languages get replaced by underscores: 
`$languages = str_replace('-', '_', $languages);` 
So to get the browserLanguagePrefix shouldn't it be exploded by underscore instead of hyphen?